### PR TITLE
Fix AVMediaType Swift 4 Error

### DIFF
--- a/framework/Source/iOS/Camera.swift
+++ b/framework/Source/iOS/Camera.swift
@@ -153,9 +153,9 @@ public class Camera: NSObject, ImageSource, AVCaptureVideoDataOutputSampleBuffer
 
         var captureConnection: AVCaptureConnection!
         for connection in videoOutput.connections {
-            for port in (connection as! AVCaptureConnection).inputPorts {
-                if (port as AnyObject).mediaType == AVMediaTypeVideo {
-                    captureConnection = connection as? AVCaptureConnection
+            for port in connection.inputPorts {
+                if port.mediaType == AVMediaType.video {
+                    captureConnection = connection
                     captureConnection.isVideoMirrored = location == .frontFacing
                 }
             }


### PR DESCRIPTION
Summary:

- Fixes the AVMediaType error in `Camera.swift` for Swift 4
- Removes unnecessary force casts now that the correct types are returned

Reviewers:
jtumarki
Brophy

Test Plan:
Compiles correctly

Revert Plan:
git revert