### PR TITLE
Add an ImageBufferInterceptor Output

### DIFF
--- a/framework/GPUImage.xcodeproj/project.pbxproj
+++ b/framework/GPUImage.xcodeproj/project.pbxproj
@@ -351,6 +351,7 @@
 		BCFF46FE1CBB0C1F00A0C521 /* AverageColorExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCFF46FD1CBB0C1F00A0C521 /* AverageColorExtractor.swift */; };
 		BCFF47081CBB443B00A0C521 /* CameraConversion.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCFF47071CBB443B00A0C521 /* CameraConversion.swift */; };
 		DC1BEF032106B5B3007FB281 /* Beautify.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCCE5E4E20FEC16700EF86F9 /* Beautify.swift */; };
+		DC1BEEFC210684FF007FB281 /* ImageBufferIntercepter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC1BEEFA210684F6007FB281 /* ImageBufferIntercepter.swift */; };
 		DCCE5E5320FEC17F00EF86F9 /* Beautify.fsh in Resources */ = {isa = PBXBuildFile; fileRef = DCCE5E5220FEC17F00EF86F9 /* Beautify.fsh */; };
 /* End PBXBuildFile section */
 
@@ -688,6 +689,7 @@
 		BCFF46FF1CBB0D8900A0C521 /* AverageColor_GL.fsh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.glsl; name = AverageColor_GL.fsh; path = Source/Operations/Shaders/AverageColor_GL.fsh; sourceTree = "<group>"; };
 		BCFF47001CBB0D8900A0C521 /* AverageColor.vsh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.glsl; name = AverageColor.vsh; path = Source/Operations/Shaders/AverageColor.vsh; sourceTree = "<group>"; };
 		BCFF47071CBB443B00A0C521 /* CameraConversion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CameraConversion.swift; path = Source/CameraConversion.swift; sourceTree = "<group>"; };
+		DC1BEEFA210684F6007FB281 /* ImageBufferIntercepter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ImageBufferIntercepter.swift; path = Source/iOS/ImageBufferIntercepter.swift; sourceTree = "<group>"; };
 		DCCE5E4E20FEC16700EF86F9 /* Beautify.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Beautify.swift; path = Source/Operations/Beautify.swift; sourceTree = "<group>"; };
 		DCCE5E5220FEC17F00EF86F9 /* Beautify.fsh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.glsl; name = Beautify.fsh; path = Source/Operations/Shaders/Beautify.fsh; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -1132,6 +1134,7 @@
 				BC9E35231E524D4D00B8604F /* RenderView.swift */,
 				BC9E35221E524D4D00B8604F /* PictureOutput.swift */,
 				BC9E35211E524D4D00B8604F /* MovieOutput.swift */,
+				DC1BEEFA210684F6007FB281 /* ImageBufferIntercepter.swift */,
 			);
 			name = iOS;
 			sourceTree = "<group>";
@@ -1566,6 +1569,7 @@
 				BC9E35611E5256A200B8604F /* TwoStageOperation.swift in Sources */,
 				BC9E35C41E5257DC00B8604F /* DarkenBlend.swift in Sources */,
 				BC9E358D1E52572E00B8604F /* SingleComponentGaussianBlur.swift in Sources */,
+				DC1BEEFC210684FF007FB281 /* ImageBufferIntercepter.swift in Sources */,
 				BC9E35361E524D7C00B8604F /* FramebufferCache.swift in Sources */,
 				BC9E359C1E52575A00B8604F /* ShiTomasiFeatureDetector.swift in Sources */,
 				BC9E358C1E52572B00B8604F /* GaussianBlur.swift in Sources */,

--- a/framework/Source/iOS/ImageBufferIntercepter.swift
+++ b/framework/Source/iOS/ImageBufferIntercepter.swift
@@ -1,0 +1,154 @@
+//
+//  ImageBufferIntercepter.swift
+//  GPUImage2
+//
+//  Created by Brophy on 7/17/18.
+//
+
+import UIKit
+import OpenGLES
+import CoreVideo
+import CoreMedia
+import AVFoundation
+
+public class ImageBufferIntercepter: ImageConsumer {
+
+    public var pixelBufferAvailableCallback:((CVPixelBuffer, CMTime) -> ())?
+    public var completedPixelBufferRenderingCallback: ((ImageBufferIntercepter) -> ())?
+    
+    var storedFramebuffer:Framebuffer?
+    
+    let size:Size
+    let colorSwizzlingShader:ShaderProgram
+    
+    var pixelBuffer:CVPixelBuffer? = nil
+    var renderFramebuffer:Framebuffer!
+    
+    private var startTime:CMTime?
+    private var previousFrameTime = kCMTimeNegativeInfinity
+    
+    public let sources = SourceContainer()
+    public let maximumInputs:UInt = 1
+    var isRecording: Bool = false
+    
+    private let pixelBufferPool: CVPixelBufferPool
+    
+    private let processingQueue: DispatchQueue = DispatchQueue(label: "ImageBufferIntercepter", qos: DispatchQoS.utility)
+    
+    public init(pixelBufferPool: CVPixelBufferPool, size: Size) {
+        if sharedImageProcessingContext.supportsTextureCaches() {
+            self.colorSwizzlingShader = sharedImageProcessingContext.passthroughShader
+        } else {
+            self.colorSwizzlingShader = crashOnShaderCompileFailure("MovieOutput"){try sharedImageProcessingContext.programForVertexShader(defaultVertexShaderForInputs(1), fragmentShader:ColorSwizzlingFragmentShader)}
+        }
+        self.size = size
+        self.pixelBufferPool = pixelBufferPool
+    }
+    
+    deinit {
+    }
+    
+    public func newFramebufferAvailable(_ framebuffer:Framebuffer, fromSourceIndex:UInt) {
+        processFramebuffer(framebuffer)
+    }
+    
+    public func startRecording() {
+        startTime = nil
+        sharedImageProcessingContext.runOperationSynchronously{
+            self.isRecording = true
+            
+            CVPixelBufferPoolCreatePixelBuffer(nil, self.pixelBufferPool, &self.pixelBuffer)
+            
+            /* AVAssetWriter will use BT.601 conversion matrix for RGB to YCbCr conversion
+             * regardless of the kCVImageBufferYCbCrMatrixKey value.
+             * Tagging the resulting video file as BT.601, is the best option right now.
+             * Creating a proper BT.709 video is not possible at the moment.
+             */
+            CVBufferSetAttachment(self.pixelBuffer!, kCVImageBufferColorPrimariesKey, kCVImageBufferColorPrimaries_ITU_R_709_2, .shouldPropagate)
+            CVBufferSetAttachment(self.pixelBuffer!, kCVImageBufferYCbCrMatrixKey, kCVImageBufferYCbCrMatrix_ITU_R_601_4, .shouldPropagate)
+            CVBufferSetAttachment(self.pixelBuffer!, kCVImageBufferTransferFunctionKey, kCVImageBufferTransferFunction_ITU_R_709_2, .shouldPropagate)
+            
+            let bufferSize = GLSize(self.size)
+            var cachedTextureRef:CVOpenGLESTexture? = nil
+            let status = CVOpenGLESTextureCacheCreateTextureFromImage(kCFAllocatorDefault, sharedImageProcessingContext.coreVideoTextureCache, self.pixelBuffer!, nil, GLenum(GL_TEXTURE_2D), GL_RGBA, bufferSize.width, bufferSize.height, GLenum(GL_BGRA), GLenum(GL_UNSIGNED_BYTE), 0, &cachedTextureRef)
+            
+            guard status == kCVReturnSuccess else {
+                print("ERROR CREATING OpenGLESTexture! Error code: \(status)")
+                self.isRecording = false
+                return
+            }
+            let cachedTexture = CVOpenGLESTextureGetName(cachedTextureRef!)
+            
+            self.renderFramebuffer = try! Framebuffer(context:sharedImageProcessingContext, orientation:.landscapeRight, size:bufferSize, textureOnly:false, overriddenTexture: cachedTexture)
+        }
+    }
+    
+    public func stopRecording(withCompletionHandler completionHandler: (() -> Void)?) {
+        sharedImageProcessingContext.runOperationSynchronously{
+            self.isRecording = false
+            sharedImageProcessingContext.runOperationAsynchronously {
+                self.completedPixelBufferRenderingCallback?(self)
+                completionHandler?()
+            }
+        }
+    }
+    
+    func renderIntoPixelBuffer(_ pixelBuffer:CVPixelBuffer, framebuffer:Framebuffer) {
+        if !sharedImageProcessingContext.supportsTextureCaches() {
+            self.renderFramebuffer = sharedImageProcessingContext.framebufferCache.requestFramebufferWithProperties(orientation:framebuffer.orientation, size:GLSize(self.size))
+            self.renderFramebuffer.lock()
+        }
+        
+        self.renderFramebuffer.activateFramebufferForRendering()
+        clearFramebufferWithColor(Color.black)
+        CVPixelBufferLockBaseAddress(pixelBuffer, CVPixelBufferLockFlags(rawValue:CVOptionFlags(0)))
+        renderQuadWithShader(self.colorSwizzlingShader, uniformSettings:ShaderUniformSettings(), vertexBufferObject:sharedImageProcessingContext.standardImageVBO, inputTextures:[framebuffer.texturePropertiesForOutputRotation(.noRotation)])
+        
+        if sharedImageProcessingContext.supportsTextureCaches() {
+            glFinish()
+        } else {
+            glReadPixels(0, 0, self.renderFramebuffer.size.width, self.renderFramebuffer.size.height, GLenum(GL_RGBA), GLenum(GL_UNSIGNED_BYTE), CVPixelBufferGetBaseAddress(pixelBuffer))
+            self.renderFramebuffer.unlock()
+        }
+    }
+    
+    
+    private func processFramebuffer(_ framebuffer: Framebuffer) {
+        guard self.isRecording else {
+            framebuffer.unlock()
+            return
+        }
+        
+        sharedImageProcessingContext.runOperationAsynchronously {
+            defer {
+                framebuffer.unlock()
+            }
+            
+            
+            // Ignore still images and other non-video updates (do I still need this?)
+            guard let frameTime = framebuffer.timingStyle.timestamp?.asCMTime else { return }
+            // If two consecutive times with the same value are added to the movie, it aborts recording, so I bail on that case
+            guard (frameTime != self.previousFrameTime) else { return }
+
+            self.previousFrameTime = frameTime
+            
+            if (self.startTime == nil) {
+                self.startTime = frameTime
+            }
+            
+            if !sharedImageProcessingContext.supportsTextureCaches() {
+                let pixelBufferStatus = CVPixelBufferPoolCreatePixelBuffer(nil, self.pixelBufferPool, &self.pixelBuffer)
+                guard ((self.pixelBuffer != nil) && (pixelBufferStatus == kCVReturnSuccess)) else { return }
+            }
+            
+            self.renderIntoPixelBuffer(self.pixelBuffer!, framebuffer:framebuffer)
+            
+            self.pixelBufferAvailableCallback?(self.pixelBuffer!, frameTime)
+            
+            CVPixelBufferUnlockBaseAddress(self.pixelBuffer!, CVPixelBufferLockFlags(rawValue:CVOptionFlags(0)))
+            if !sharedImageProcessingContext.supportsTextureCaches() {
+                self.pixelBuffer = nil
+            }
+        }
+    }
+}


### PR DESCRIPTION
Summary:

- Adds an Output that exposes the CVPixelBuffer & Presentation Timestamp of each frame
- Output has a completion block that is called for each frame with the CVPixelBuffer converted
    using the provided PixelBufferPool.
- Output also has a completion block for when the recording has stopped and all frames
    have been processed
- Usage should follow the pattern of:
    - initialize using a `CVPixelBufferPool` from your `AVAssetWriterInputPixelBufferAdaptor`
    - set your callbacks
    - call `startRecording()`
    - [frames will be processed]
    - call `stopRecording()`
- based heavily on the MovieOutput class

Reviewers:
jtumarki
Brophy

Test Plan:
No good tests written
Been using it along with the camera test project

Revert Plan:
git revert