### PR TITLE
Safely get framebuffers in Camera

### DIFF
--- a/framework/Source/iOS/Camera.swift
+++ b/framework/Source/iOS/Camera.swift
@@ -188,8 +188,10 @@ public class Camera: NSObject, ImageSource, AVCaptureVideoDataOutputSampleBuffer
         guard (frameRenderingSemaphore.wait(timeout:DispatchTime.now()) == DispatchTimeoutResult.success) else { return }
     
         let startTime = CFAbsoluteTimeGetCurrent()
-        
-        let cameraFrame = CMSampleBufferGetImageBuffer(sampleBuffer)!
+        guard let cameraFrame = CMSampleBufferGetImageBuffer(sampleBuffer) else {
+            frameRenderingSemaphore.signal()
+            return
+        }
         let bufferWidth = CVPixelBufferGetWidth(cameraFrame)
         let bufferHeight = CVPixelBufferGetHeight(cameraFrame)
         let currentTime = CMSampleBufferGetPresentationTimeStamp(sampleBuffer)


### PR DESCRIPTION
Summary:

- The crash we've been seeing when switching cameras comes from force
    unwrapping `CMSampleBufferGetImageBuffer(sampleBuffer)`
- This adds a guard around it

Reviewers:
jtumarki
Brophy

Test Plan:
Spammed some camera swapping and seemed to fix it

Revert Plan:
git revert